### PR TITLE
Allow session handoffs

### DIFF
--- a/Pod/Classes/Camera/SBCameraViewController.h
+++ b/Pod/Classes/Camera/SBCameraViewController.h
@@ -49,4 +49,8 @@
                    initialCaptureType:(SBCaptureType)captureType
                   allowedCaptureTypes:(SBCaptureType)allowedCaptureTypes;
 
+- (instancetype)initWithCaptureViewController:(SBCaptureViewController *)captureViewController;
+
+@property (nonatomic, readonly) SBCaptureViewController *captureViewController;
+
 @end

--- a/Pod/Classes/Camera/SBCameraViewController.m
+++ b/Pod/Classes/Camera/SBCameraViewController.m
@@ -43,11 +43,19 @@
 }
 
 - (instancetype)initWithReviewOptions:(SBReviewViewOptions)options initialCaptureType:(SBCaptureType)captureType allowedCaptureTypes:(SBCaptureType)allowedCaptureTypes {
+    SBCaptureViewController *vc = [[SBCaptureViewController alloc] initWithInitialCaptureType:captureType allowedCaptureTypes:allowedCaptureTypes];
+    vc.reviewOptions = options;
+    
+    return [self initWithCaptureViewController:vc];
+}
+
+- (instancetype)initWithCaptureViewController:(SBCaptureViewController *)captureViewController {
+    NSParameterAssert(captureViewController);
+    
     if (self = [super init]) {
-        SBCaptureViewController *controller = [[SBCaptureViewController alloc] initWithInitialCaptureType:captureType allowedCaptureTypes:allowedCaptureTypes];
-        controller.reviewOptions = options;
-        [self setViewControllers:@[controller]];
+        [self setViewControllers:@[_captureViewController = captureViewController]];
     }
+    
     return self;
 }
 

--- a/Pod/Classes/Camera/SBCaptureManager.h
+++ b/Pod/Classes/Camera/SBCaptureManager.h
@@ -26,6 +26,8 @@ typedef NS_ENUM(NSUInteger, SBCaptureFlashMode) {
  */
 @interface SBCaptureManager : NSObject
 
+- (instancetype) initWithSession:(AVCaptureSession*) captureSession;
+
 @property (nonatomic) AVCaptureSession *captureSession;
 
 @property (nonatomic, readonly) SBVideoManager *videoManager;

--- a/Pod/Classes/Camera/SBCaptureViewController.h
+++ b/Pod/Classes/Camera/SBCaptureViewController.h
@@ -70,4 +70,6 @@
  */
 - (instancetype)initWithInitialCaptureType:(SBCaptureType)captureType allowedCaptureTypes:(SBCaptureType)allowedCaptureTypes;
 
+- (instancetype)initWithInitialCaptureType:(SBCaptureType)captureType allowedCaptureTypes:(SBCaptureType)allowedCaptureTypes captureSession:(AVCaptureSession *)session;
+
 @end

--- a/Pod/Classes/Camera/SBCaptureViewController.m
+++ b/Pod/Classes/Camera/SBCaptureViewController.m
@@ -74,12 +74,6 @@
     return _assetManager;
 }
 
-- (SBCaptureManager*) captureManager {
-    if (!_captureManager)
-        _captureManager = [[SBCaptureManager alloc] init];
-    return _captureManager;
-}
-
 - (SBCameraView*) cameraView {
     if (!_cameraView) {
         _cameraView = [[SBCameraView alloc] initWithFrame:self.view.frame captureManager:self.captureManager];
@@ -116,8 +110,13 @@
 }
 
 - (instancetype)initWithInitialCaptureType:(SBCaptureType)captureType allowedCaptureTypes:(SBCaptureType)allowedCaptureTypes {
-    if (self = [super init]) {
+    return [self initWithInitialCaptureType:captureType allowedCaptureTypes:allowedCaptureTypes captureSession:nil];
+}
 
+- (instancetype)initWithInitialCaptureType:(SBCaptureType)captureType allowedCaptureTypes:(SBCaptureType)allowedCaptureTypes captureSession:(AVCaptureSession *)session {
+    if (self = [super init]) {
+        _captureManager = [[SBCaptureManager alloc] initWithSession:session ?: [AVCaptureSession new]];
+        
         BOOL allowsPhoto = (allowedCaptureTypes & SBCaptureTypePhoto) != 0;
         BOOL allowsVideo = (allowedCaptureTypes & SBCaptureTypeVideo) != 0;
         


### PR DESCRIPTION
These code changes make it possible to utilize this library's capture/camera view controllers when you are transitioning from an existing view that is using a capture session object. As of this time, iOS only permits one active visible capture layer for one active capture session, so you must hand it off.