### PR TITLE
disallow very short videos and duplicate URLs in the asset stitcher

### DIFF
--- a/Pod/Classes/Camera/NSURL+Camera.m
+++ b/Pod/Classes/Camera/NSURL+Camera.m
@@ -17,11 +17,11 @@ NSString *SBDocumentsDirectory() {
 @implementation NSURL (Camera)
 
 + (instancetype) randomDocumentsFileURLWithPrefix:(NSString*)prefix extension:(NSString*)extension {
-    return [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@-%ld.%@", SBDocumentsDirectory(), prefix, (long)[[NSDate date] timeIntervalSince1970], extension]];
+    return [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@-%@.%@", SBDocumentsDirectory(), prefix, [[NSUUID UUID] UUIDString] , extension]];
 }
 
 + (instancetype) randomTemporaryFileURLWithPrefix:(NSString*)prefix extension:(NSString*)extension {
-    return [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@-%ld.%@", NSTemporaryDirectory(), prefix, (long)[[NSDate date] timeIntervalSince1970], extension]];
+    return [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/%@-%@.%@", NSTemporaryDirectory(), prefix, [[NSUUID UUID] UUIDString], extension]];
 }
 
 + (instancetype) randomTemporaryMP4FileURLWithPrefix:(NSString*)prefix {

--- a/Pod/Classes/Camera/SBAssetStitcher.m
+++ b/Pod/Classes/Camera/SBAssetStitcher.m
@@ -79,8 +79,6 @@
     if (CMTimeGetSeconds(comp.asset.duration) > .2 && ![self.compositionFileURLs containsObject:comp.outputURL]) {
         [self.compositionFileURLs addObject:comp.outputURL];
         [self.compositions addObject:comp];
-    } else {
-        NSLog(@"Video segment too short");
     }
 }
 

--- a/Pod/Classes/Camera/SBAssetStitcher.m
+++ b/Pod/Classes/Camera/SBAssetStitcher.m
@@ -76,10 +76,8 @@
     comp.devicePosition = devicePosition;
     comp.outputURL = [NSURL randomTemporaryMP4FileURLWithPrefix:@"composition"];
 
-    if (CMTimeGetSeconds(comp.asset.duration) > .2 && ![self.compositionFileURLs containsObject:comp.outputURL]) {
-        [self.compositionFileURLs addObject:comp.outputURL];
-        [self.compositions addObject:comp];
-    }
+    [self.compositionFileURLs addObject:comp.outputURL];
+    [self.compositions addObject:comp];
 }
 
 - (RACSignal*)exportTo:(NSURL *)outputFileURL options:(SBAssetStitcherOptions *)options {

--- a/Pod/Classes/Camera/SBAssetStitcher.m
+++ b/Pod/Classes/Camera/SBAssetStitcher.m
@@ -76,8 +76,12 @@
     comp.devicePosition = devicePosition;
     comp.outputURL = [NSURL randomTemporaryMP4FileURLWithPrefix:@"composition"];
 
-    [self.compositionFileURLs addObject:comp.outputURL];
-    [self.compositions addObject:comp];
+    if (CMTimeGetSeconds(comp.asset.duration) > .2 && ![self.compositionFileURLs containsObject:comp.outputURL]) {
+        [self.compositionFileURLs addObject:comp.outputURL];
+        [self.compositions addObject:comp];
+    } else {
+        NSLog(@"Video segment too short");
+    }
 }
 
 - (RACSignal*)exportTo:(NSURL *)outputFileURL options:(SBAssetStitcherOptions *)options {


### PR DESCRIPTION
- Very short duration videos can lead to video decoding failure error, so disallow them as well as any attempts to save at existing URL path.