### PR TITLE
elim max duration constraint on movieFileOutput

### DIFF
--- a/Pod/Classes/Camera/SBAssetStitcher.m
+++ b/Pod/Classes/Camera/SBAssetStitcher.m
@@ -118,7 +118,15 @@
             [subscriber sendError:error];
             return nil;
         }
-        
+
+        // Trim final video to exactly 10 seconds.
+        float duration = CMTimeGetSeconds(composition.duration);
+        if (duration > 10.0f) {
+            CMTime maxLength = CMTimeMakeWithSeconds(10.f, 600);
+            CMTime excess = CMTimeSubtract(composition.duration, maxLength);
+            [composition removeTimeRange:CMTimeRangeMake(maxLength, excess)];
+        }
+
         SBComposition *finalComposition = [[SBComposition alloc] initWithAsset:composition];
         finalComposition.outputURL = outputFileURL;
         finalComposition.orientation = AVCaptureVideoOrientationLandscapeRight; //don't rotate this composition

--- a/Pod/Classes/Camera/SBCaptureViewController.m
+++ b/Pod/Classes/Camera/SBCaptureViewController.m
@@ -218,13 +218,14 @@
     }];
     
     //enable/disable record button when time is at max duration
-    [[[[self.captureManager.videoManager totalTimeRecordedSignal] deliverOn:[RACScheduler mainThreadScheduler]] map:^NSNumber*(NSValue* value) {
+    [[[[[self.captureManager.videoManager totalTimeRecordedSignal] deliverOn:[RACScheduler mainThreadScheduler]] map:^NSNumber*(NSValue* value) {
         @strongify(self);
         return @(CMTimeGetSeconds([value CMTimeValue]) < self.captureManager.videoManager.maxDuration);
-    }] subscribeNext:^(NSNumber *enabled) {
-        @strongify(self);
-        self.cameraView.recordButton.enabled = enabled.boolValue;
-    }];
+    }] distinctUntilChanged]
+     subscribeNext:^(NSNumber *enabled) {
+         @strongify(self);
+         self.cameraView.recordButton.enabled = enabled.boolValue;
+     }];
     
     RAC(self.cameraView.progressBar, value) = [[[self.captureManager.videoManager recordDurationChangeSignal] skip:1] map:^id(NSValue* value) {
         return @(CMTimeGetSeconds([value CMTimeValue]));

--- a/Pod/Classes/Camera/SBComposition.m
+++ b/Pod/Classes/Camera/SBComposition.m
@@ -111,7 +111,7 @@
     AVAssetExportSession *exporter = [AVAssetExportSession exportSessionWithAsset:self.asset presetName:self.exportPreset outputURL:self.outputURL];
     exporter.videoComposition = videoComposition;
 
-    // Video composition validation -> helpful with debugging
+    // Video composition validation -> helpful in debugging export session failure.
     [exporter.videoComposition isValidForAsset:exporter.asset timeRange:exporter.timeRange validationDelegate:self];
 
     return exporter;

--- a/Pod/Classes/Camera/SBComposition.m
+++ b/Pod/Classes/Camera/SBComposition.m
@@ -13,7 +13,7 @@
 #import <ReactiveCocoa/ReactiveCocoa.h>
 #import <ReactiveCocoa/RACEXTScope.h>
 
-@interface SBComposition ()
+@interface SBComposition () <AVVideoCompositionValidationHandling>
 @end
 
 @implementation SBComposition
@@ -110,6 +110,10 @@
     [[NSFileManager defaultManager] removeItemAtURL:self.outputURL error:nil];
     AVAssetExportSession *exporter = [AVAssetExportSession exportSessionWithAsset:self.asset presetName:self.exportPreset outputURL:self.outputURL];
     exporter.videoComposition = videoComposition;
+
+    // Video composition validation -> helpful with debugging
+    [exporter.videoComposition isValidForAsset:exporter.asset timeRange:exporter.timeRange validationDelegate:self];
+
     return exporter;
 }
 
@@ -119,6 +123,28 @@
     return [[exporter exportAsynchronously] map:^AVAsset*(NSURL *savedToURL) {
         return [[AVURLAsset alloc] initWithURL:savedToURL options:@{AVURLAssetPreferPreciseDurationAndTimingKey:@YES}];
     }];
+}
+
+#pragma mark - AVVideoCompositionValidationHandling delegate
+
+-(BOOL)videoComposition:(AVVideoComposition *)videoComposition shouldContinueValidatingAfterFindingEmptyTimeRange:(CMTimeRange)timeRange {
+    NSLog(@"Empty time range in Video Composition");
+    return NO;
+}
+
+-(BOOL)videoComposition:(AVVideoComposition *)videoComposition shouldContinueValidatingAfterFindingInvalidTimeRangeInInstruction:(id<AVVideoCompositionInstruction>)videoCompositionInstruction {
+    NSLog(@"Invalid time range instruction in Video Composition");
+    return NO;
+}
+
+-(BOOL)videoComposition:(AVVideoComposition *)videoComposition shouldContinueValidatingAfterFindingInvalidTrackIDInInstruction:(id<AVVideoCompositionInstruction>)videoCompositionInstruction layerInstruction:(AVVideoCompositionLayerInstruction *)layerInstruction asset:(AVAsset *)asset {
+    NSLog(@"Invalid track ID instruction in Video Composition");
+    return NO;
+}
+
+-(BOOL)videoComposition:(AVVideoComposition *)videoComposition shouldContinueValidatingAfterFindingInvalidValueForKey:(NSString *)key {
+    NSLog(@"Invalid value for key in Video Composition");
+    return NO;
 }
 
 @end

--- a/Pod/Classes/Camera/SBReviewView.m
+++ b/Pod/Classes/Camera/SBReviewView.m
@@ -496,4 +496,5 @@ static CGFloat const kAnimationVelocity = 0.5f;
     [self animateLayoutChangeWithDuration:animationDuration damping:.95 velocity:.5 completion:nil];
 }
 
+
 @end


### PR DESCRIPTION
Remove maxRecordedDuration constraint on AVCaptureMovieFileOutput. Instead, pause recording when recordedDuration hits 10s. This should prevent the creation of any empty time ranges in the AVVideoComposition that will cause failure on export.